### PR TITLE
Fix template loading for production GitHub Pages deployment

### DIFF
--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -122,12 +122,19 @@ export class Router {
 
     private async loadTemplate(templatePath: string): Promise<void> {
         try {
-            const response = await fetch(templatePath);
-            if (!response.ok) {
-                throw new Error(`Failed to load template: ${response.status} ${response.statusText}`);
+            // Import templates from bundled module
+            const { getTemplate } = await import('../templates');
+
+            // Convert template path to route path for template lookup
+            const routePath = templatePath.replace('/src/templates', '').replace('.html', '');
+            const normalizedPath = routePath === '/home' ? '/' : routePath;
+
+            const html = getTemplate(normalizedPath);
+
+            if (!html) {
+                throw new Error(`Template not found for path: ${normalizedPath}`);
             }
 
-            const html = await response.text();
             const appElement = document.getElementById('app');
 
             if (!appElement) {
@@ -175,6 +182,6 @@ export class Router {
     }
 }
 
-export function createRouter(options?: RouterOptions): Router {
+export const createRouter = (options?: RouterOptions): Router => {
     return new Router(options);
 }

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,0 +1,21 @@
+// Template imports - Vite will bundle these as text
+import homeTemplate from './home.html?raw';
+import contactTemplate from './contact.html?raw';
+import joinTemplate from './join.html?raw';
+import tryAClassTemplate from './try-a-class.html?raw';
+import loginTemplate from './login.html?raw';
+
+export const templates = {
+  '/': homeTemplate,
+  '/home': homeTemplate,
+  '/contact': contactTemplate,
+  '/join': joinTemplate,
+  '/try-a-class': tryAClassTemplate,
+  '/login': loginTemplate
+} as const;
+
+export type TemplatePath = keyof typeof templates;
+
+export const getTemplate = (path: string): string | null => {
+  return templates[path as TemplatePath] || null;
+};


### PR DESCRIPTION
- Create template bundling system using Vite's ?raw imports
- Update router to use bundled templates instead of fetch requests
- Add src/templates/index.ts to import and export all templates as text
- Resolve 404 errors when loading templates in production builds
- Ensure compatibility with GitHub Pages base path configuration

🤖 Generated with [Claude Code](https://claude.ai/code)