### PR TITLE
Fix image 404 errors by implementing proper base path handling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,13 @@ const handleHomeRoute = (): void => {
 const boot = async (): Promise<void> => {
     themeConfiguration();
 
+    // Update static image paths for production
+    const { getAssetUrl } = await import('./utils/base-path');
+    const footerLogo = document.querySelector('footer img[src="/images/brand/oregon-jiu-jitsu-lab.svg"]');
+    if (footerLogo) {
+        footerLogo.setAttribute('src', getAssetUrl('/images/brand/oregon-jiu-jitsu-lab.svg'));
+    }
+
     const router = createRouter({ mode: 'hash' });
 
     router

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -5,7 +5,10 @@ import joinTemplate from './join.html?raw';
 import tryAClassTemplate from './try-a-class.html?raw';
 import loginTemplate from './login.html?raw';
 
-export const templates = {
+// Import base path utility
+import { replaceImagePaths } from '../utils/base-path';
+
+const templates = {
   '/': homeTemplate,
   '/home': homeTemplate,
   '/contact': contactTemplate,
@@ -17,5 +20,6 @@ export const templates = {
 export type TemplatePath = keyof typeof templates;
 
 export const getTemplate = (path: string): string | null => {
-  return templates[path as TemplatePath] || null;
+  const template = templates[path as TemplatePath];
+  return template ? replaceImagePaths(template) : null;
 };

--- a/src/utils/base-path.ts
+++ b/src/utils/base-path.ts
@@ -1,0 +1,25 @@
+/**
+ * Get the base path for the application
+ * This handles both development (/) and production (/ojjlab.com/) environments
+ */
+export const getBasePath = (): string => {
+  return import.meta.env.BASE_URL || '/';
+};
+
+/**
+ * Get the full URL for a public asset
+ * @param path - Path relative to public directory (e.g., '/images/logo.svg')
+ */
+export const getAssetUrl = (path: string): string => {
+  const basePath = getBasePath();
+  const cleanPath = path.startsWith('/') ? path.slice(1) : path;
+
+  return basePath === '/' ? `/${cleanPath}` : `${basePath}${cleanPath}`;
+};
+
+/**
+ * Replace image paths in HTML with correct base path
+ */
+export const replaceImagePaths = (html: string): string => {
+  return html.replace(/src="\/images\//g, `src="${getAssetUrl('/images/')}`);
+};


### PR DESCRIPTION
- Create base path utility for GitHub Pages deployment compatibility
- Update template system to replace image paths with correct base URLs
- Add static image path updates for footer logo
- Follow Vite best practices using public directory for static assets
- Resolve production 404s for brand logos, hero image, and program images

🤖 Generated with [Claude Code](https://claude.ai/code)