### PR TITLE
fix: Update image paths in components to use getAssetUrl for production

### DIFF
--- a/src/components/gallery.ts
+++ b/src/components/gallery.ts
@@ -1,6 +1,7 @@
 import gsap from 'gsap';
 import ScrollTrigger from 'gsap/ScrollTrigger';
 import type { Timeline } from '../model/gsap';
+import { getAssetUrl } from '../utils/base-path';
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -83,9 +84,10 @@ class OJJGallery extends HTMLElement {
 
     // Generate exactly 36 items (6x6 grid)
     for (let i = 1; i <= 36; i++) {
+      const imagePath = getAssetUrl(`/images/gallery/${i}.svg`);
       items.push(`
-        <button class="gallery-item" data-image="/images/gallery/${i}.svg" aria-label="Open gallery image ${i}">
-          <img src="/images/gallery/${i}.svg" alt="Gallery image ${i}" class="gallery-image">
+        <button class="gallery-item" data-image="${imagePath}" aria-label="Open gallery image ${i}">
+          <img src="${imagePath}" alt="Gallery image ${i}" class="gallery-image">
         </button>
       `);
     }
@@ -316,7 +318,9 @@ class OJJGallery extends HTMLElement {
   private updateModalImage(): void {
     if (!this.modalImage) return;
 
-    const newImageSrc = `/images/gallery/${this.currentImageIndex + 1}.svg`;
+    const newImageSrc = getAssetUrl(
+      `/images/gallery/${this.currentImageIndex + 1}.svg`
+    );
     const newImageAlt = `Gallery image ${this.currentImageIndex + 1}`;
 
     // Animate image transition

--- a/src/components/mobile-navigation.ts
+++ b/src/components/mobile-navigation.ts
@@ -1,4 +1,5 @@
 import { MobileNavAnimation } from '../animations/mobile-nav';
+import { getAssetUrl } from '../utils/base-path';
 
 export class MobileNavigationComponent extends HTMLElement {
   private mobileNavAnimation: MobileNavAnimation;
@@ -28,8 +29,8 @@ export class MobileNavigationComponent extends HTMLElement {
                     <!-- Logo -->
                     <div class="mobile-nav-logo">
                         <a href="/" data-route="/">
-                            <img class="block dark:hidden h-6 w-auto" src="/images/brand/oregon-jiu-jitsu-lab.svg" alt="Oregon Jiu Jitsu Lab"/>
-                            <img class="hidden dark:block h-6 w-auto" src="/images/brand/oregon-jiu-jitsu-lab-light.svg" alt="Oregon Jiu Jitsu Lab"/>
+                            <img class="block dark:hidden h-6 w-auto" src="${getAssetUrl('/images/brand/oregon-jiu-jitsu-lab.svg')}" alt="Oregon Jiu Jitsu Lab"/>
+                            <img class="hidden dark:block h-6 w-auto" src="${getAssetUrl('/images/brand/oregon-jiu-jitsu-lab-light.svg')}" alt="Oregon Jiu Jitsu Lab"/>
                         </a>
                     </div>
 

--- a/src/components/navigation.ts
+++ b/src/components/navigation.ts
@@ -1,3 +1,5 @@
+import { getAssetUrl } from '../utils/base-path';
+
 export class NavigationComponent extends HTMLElement {
   public connectedCallback(): void {
     this.innerHTML = this.getTemplate();
@@ -10,8 +12,8 @@ export class NavigationComponent extends HTMLElement {
                 <!-- Logo -->
                 <div class="nav-logo">
                     <a href="/" data-route="/">
-                        <img class="block dark:hidden h-8 w-auto" src="/images/brand/oregon-jiu-jitsu-lab-light.svg" alt="Oregon Jiu Jitsu Lab"/>
-                        <img class="hidden dark:block h-8 w-auto" src="/images/brand/oregon-jiu-jitsu-lab.svg" alt="Oregon Jiu Jitsu Lab"/>
+                        <img class="block dark:hidden h-8 w-auto" src="${getAssetUrl('/images/brand/oregon-jiu-jitsu-lab-light.svg')}" alt="Oregon Jiu Jitsu Lab"/>
+                        <img class="hidden dark:block h-8 w-auto" src="${getAssetUrl('/images/brand/oregon-jiu-jitsu-lab.svg')}" alt="Oregon Jiu Jitsu Lab"/>
                     </a>
                 </div>
 


### PR DESCRIPTION
- Fix gallery component to use getAssetUrl() for all image references
- Fix navigation component logos to use proper base path
- Fix mobile navigation logos to use proper base path
- Ensures images load correctly with ojjlab.com prefix in production